### PR TITLE
Adds support for ES6 modules

### DIFF
--- a/lib/rules/no-require-lodash.js
+++ b/lib/rules/no-require-lodash.js
@@ -17,6 +17,15 @@ module.exports = function(context) {
         context.report(node, "Only require specific lodash modules that you need.");
       }
     },
+    "ImportDeclaration": function(node) {
+      if (
+        node.source &&
+          node.source.type === 'Literal' &&
+          node.source.value === 'lodash'
+      ) {
+        context.report(node, "Only import specific lodash modules that you need.");
+      }
+    },
   };
 };
 

--- a/test/no-require-lodash.js
+++ b/test/no-require-lodash.js
@@ -14,6 +14,11 @@ var rule = require("../lib/rules/no-require-lodash"),
 
     RuleTester = require("eslint").RuleTester;
 
+RuleTester.setDefaultConfig({
+  ecmaFeatures: {
+    modules: true
+  },
+});
 
 //------------------------------------------------------------------------------
 // Tests
@@ -23,7 +28,11 @@ var ruleTester = new RuleTester();
 ruleTester.run("no-require-lodash", rule, {
 
   valid: [
-    "require('lodash/colleciton/map')"
+    "require('lodash/colleciton/map')",
+    "require('some-package')",
+    "import map from 'lodash/colleciton/map'",
+    "import SomePackage from 'some-package'",
+    "import {a, b} from 'some-package'"
   ],
 
   invalid: [
@@ -32,6 +41,20 @@ ruleTester.run("no-require-lodash", rule, {
       errors: [{
         message: "Only require specific lodash modules that you need.",
         type: "CallExpression"
+      }]
+    },
+    {
+      code: "import lodash from 'lodash'",
+      errors: [{
+        message: "Only import specific lodash modules that you need.",
+        type: "ImportDeclaration"
+      }]
+    },
+    {
+      code: "import {map} from 'lodash'",
+      errors: [{
+        message: "Only import specific lodash modules that you need.",
+        type: "ImportDeclaration"
       }]
     }
   ]


### PR DESCRIPTION
This commit adds the ability to also check the ES6 module import syntax:

Mark:
`import lodash from 'lodash';`

Expect:
`import map from 'lodash/collection/map';`

Tests were added.
